### PR TITLE
feat: Make SoA types clonable with SoaClone

### DIFF
--- a/soa-rs-testing/src/lib.rs
+++ b/soa-rs-testing/src/lib.rs
@@ -7,7 +7,7 @@
 #[derive(Soars)]
 struct AllowUnknownAttributes;
 
-use soa_rs::{AsMutSlice, AsSlice, AsSoaRef, Soa, Soars, soa};
+use soa_rs::{AsMutSlice, AsSlice, AsSoaRef, Soa, SoaClone, Soars, soa};
 use std::sync::Mutex;
 
 #[derive(Soars, Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -81,7 +81,7 @@ struct Unit;
 #[soa_derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Empty {}
 
-#[derive(Soars, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Soars, SoaClone, Clone, Copy, PartialEq, Eq, Default, Debug)]
 #[soa_derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct EmptyTuple();
 
@@ -92,7 +92,7 @@ struct ZstFields {
     b: (),
 }
 
-#[derive(Soars, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Soars, SoaClone, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[soa_derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct Tuple(u8, u16, u32);
 
@@ -291,7 +291,7 @@ pub fn clone() {
 
 #[test]
 pub fn clone_from() {
-    let mut dst: Soa<_> = core::iter::repeat(Tuple(100, 100, 100)).take(7).collect();
+    let mut dst: Soa<_> = std::iter::repeat_n(Tuple(100, 100, 100), 7).collect();
     let src: Soa<_> = [Tuple(1, 2, 3), Tuple(4, 5, 6), Tuple(7, 8, 9)].into();
     dst.clone_from(&src);
     assert_eq!(dst, src);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 //! Soars makes it simple to work with the structure-of-arrays memory layout.
 //! What [`Vec`] is to array-of-structures, [`Soa`] is to structure-of-arrays.
 //!
-//! [`Vec`]: __alloc::vec::Vec
-//!
 //! # Examples
 //!
 //! First, derive [`Soars`] for your type:
@@ -157,6 +155,7 @@
 /// from the library for consumption instead.
 #[doc(hidden)]
 pub extern crate alloc as __alloc;
+pub(crate) use __alloc::vec::Vec;
 
 mod soa;
 pub use soa::Soa;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,5 +1,7 @@
+use __alloc::vec::Vec;
+
 use crate::{
-    AsMutSlice, AsSlice, Iter, IterMut, SliceMut, SliceRef, SoaDeref, SoaRaw, Soars,
+    AsMutSlice, AsSlice, Iter, IterMut, SliceMut, SliceRef, SoaClone, SoaDeref, SoaRaw, Soars,
     chunks_exact::ChunksExact, index::SoaIndex, iter_raw::IterRaw,
 };
 use core::{
@@ -963,6 +965,26 @@ where
 {
     fn as_mut(&mut self) -> &mut Self {
         self
+    }
+}
+
+impl<T> From<&Slice<T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: &Slice<T>) -> Self {
+        value.iter().map(SoaClone::soa_clone).collect()
+    }
+}
+
+impl<T> From<&mut Slice<T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: &mut Slice<T>) -> Self {
+        value.as_ref().into()
     }
 }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,7 +1,5 @@
-use __alloc::vec::Vec;
-
 use crate::{
-    AsMutSlice, AsSlice, Iter, IterMut, SliceMut, SliceRef, SoaClone, SoaDeref, SoaRaw, Soars,
+    AsMutSlice, AsSlice, Iter, IterMut, SliceMut, SliceRef, SoaClone, SoaDeref, SoaRaw, Soars, Vec,
     chunks_exact::ChunksExact, index::SoaIndex, iter_raw::IterRaw,
 };
 use core::{
@@ -31,7 +29,6 @@ use core::{
 /// pointers alongside the length. Therefore, SoA slice references cannot be
 /// created on the stack and returned like normal slices can.
 ///
-/// [`Vec`]: crate::__alloc::vec::Vec
 /// [`Soa`]: crate::Soa
 /// [`SliceRef`]: crate::SliceRef
 /// [`SliceMut`]: crate::SliceMut

--- a/src/slice_mut.rs
+++ b/src/slice_mut.rs
@@ -1,4 +1,6 @@
-use crate::{AsMutSlice, AsSlice, IterMut, Slice, SliceRef, Soars, iter_raw::IterRaw};
+use __alloc::vec::Vec;
+
+use crate::{AsMutSlice, AsSlice, IterMut, Slice, SliceRef, SoaClone, Soars, iter_raw::IterRaw};
 use core::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,
@@ -181,6 +183,16 @@ where
     T: Soars,
     for<'a> T::Ref<'a>: Eq,
 {
+}
+
+impl<T> From<SliceMut<'_, T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: SliceMut<T>) -> Self {
+        value.as_ref().into()
+    }
 }
 
 impl<T> AsSlice for SliceMut<'_, T>

--- a/src/slice_mut.rs
+++ b/src/slice_mut.rs
@@ -1,6 +1,6 @@
-use __alloc::vec::Vec;
-
-use crate::{AsMutSlice, AsSlice, IterMut, Slice, SliceRef, SoaClone, Soars, iter_raw::IterRaw};
+use crate::{
+    AsMutSlice, AsSlice, IterMut, Slice, SliceRef, SoaClone, Soars, Vec, iter_raw::IterRaw,
+};
 use core::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,

--- a/src/slice_ref.rs
+++ b/src/slice_ref.rs
@@ -1,4 +1,6 @@
-use crate::{AsSlice, Iter, Slice, Soars, iter_raw::IterRaw};
+use __alloc::vec::Vec;
+
+use crate::{AsSlice, Iter, Slice, SoaClone, Soars, iter_raw::IterRaw};
 use core::{
     borrow::Borrow,
     cmp::Ordering,
@@ -162,6 +164,16 @@ where
     T: Soars,
     for<'a> T::Ref<'a>: Eq,
 {
+}
+
+impl<T> From<SliceRef<'_, T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: SliceRef<T>) -> Self {
+        value.as_ref().into()
+    }
 }
 
 impl<T> AsSlice for SliceRef<'_, T>

--- a/src/slice_ref.rs
+++ b/src/slice_ref.rs
@@ -1,6 +1,4 @@
-use __alloc::vec::Vec;
-
-use crate::{AsSlice, Iter, Slice, SoaClone, Soars, iter_raw::IterRaw};
+use crate::{AsSlice, Iter, Slice, SoaClone, Soars, Vec, iter_raw::IterRaw};
 use core::{
     borrow::Borrow,
     cmp::Ordering,

--- a/src/soa.rs
+++ b/src/soa.rs
@@ -679,31 +679,18 @@ where
     }
 }
 
-// NOTE: Copy is the required bound because calling Clone::clone on a
-// stack-allocated element is unsound in the presence of interior mutability
-// unless the fields are written back, which we also can't do because of &self.
 impl<T> Clone for Soa<T>
 where
-    T: Soars + Copy,
+    T: SoaClone,
 {
     fn clone(&self) -> Self {
-        let mut out = Self::with_capacity(self.len);
-        for i in 0..self.len {
-            // SAFETY: i is in-bounds
-            let el = unsafe { self.raw.offset(i).get() };
-            out.push(el);
-        }
-        out
+        self.iter().map(SoaClone::soa_clone).collect()
     }
 
     fn clone_from(&mut self, source: &Self) {
         self.clear();
         self.reserve_exact(source.len);
-        for i in 0..source.len {
-            // SAFETY: i is in-bounds
-            let el = unsafe { source.raw.offset(i).get() };
-            self.push(el);
-        }
+        self.extend(source.iter().map(SoaClone::soa_clone));
     }
 }
 

--- a/src/soa.rs
+++ b/src/soa.rs
@@ -1,6 +1,7 @@
+use crate::__alloc::vec::Vec;
 use crate::{
-    AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef, SoaRaw, Soars,
-    iter_raw::IterRaw,
+    AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef, SoaClone, SoaRaw,
+    Soars, iter_raw::IterRaw,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -24,7 +25,6 @@ use core::{
 ///
 /// See the top-level [`soa_rs`] docs for usage examples.
 ///
-/// [`Vec`]: crate::__alloc::vec::Vec
 /// [`soa_rs`]: crate
 pub struct Soa<T>
 where
@@ -751,7 +751,7 @@ where
 {
     /// Allocate a `Soa<T>` and fill it by cloning `value`'s items.
     fn from(value: &[T; N]) -> Self {
-        value.iter().cloned().collect()
+        value.as_ref().into()
     }
 }
 
@@ -761,7 +761,7 @@ where
 {
     /// Allocate a `Soa<T>` and fill it by cloning `value`'s items.
     fn from(value: &mut [T; N]) -> Self {
-        value.iter().cloned().collect()
+        value.as_ref().into()
     }
 }
 
@@ -781,7 +781,57 @@ where
 {
     /// Allocate a `Soa<T>` and fill it by cloning `value`'s items.
     fn from(value: &mut [T]) -> Self {
-        value.iter().cloned().collect()
+        value.as_ref().into()
+    }
+}
+
+impl<T> From<Soa<T>> for Vec<T>
+where
+    T: Soars,
+{
+    /// Allocate a `Vec<T>` and fill it by moving the contents of `value`.
+    fn from(value: Soa<T>) -> Self {
+        value.into_iter().collect()
+    }
+}
+
+impl<T> From<&Slice<T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: &Slice<T>) -> Self {
+        value.iter().map(SoaClone::soa_clone).collect()
+    }
+}
+
+impl<T> From<&mut Slice<T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: &mut Slice<T>) -> Self {
+        value.as_ref().into()
+    }
+}
+
+impl<T> From<SliceRef<'_, T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: SliceRef<T>) -> Self {
+        value.as_ref().into()
+    }
+}
+
+impl<T> From<SliceMut<'_, T>> for Vec<T>
+where
+    T: SoaClone,
+{
+    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
+    fn from(value: SliceMut<T>) -> Self {
+        value.as_ref().into()
     }
 }
 

--- a/src/soa.rs
+++ b/src/soa.rs
@@ -1,6 +1,6 @@
 use crate::{
-    __alloc::vec::Vec, AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef,
-    SoaClone, SoaRaw, Soars, iter_raw::IterRaw,
+    AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef, SoaClone, SoaRaw,
+    Soars, Vec, iter_raw::IterRaw,
 };
 use core::{
     borrow::{Borrow, BorrowMut},

--- a/src/soa.rs
+++ b/src/soa.rs
@@ -1,7 +1,6 @@
-use crate::__alloc::vec::Vec;
 use crate::{
-    AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef, SoaClone, SoaRaw,
-    Soars, iter_raw::IterRaw,
+    __alloc::vec::Vec, AsMutSlice, AsSlice, IntoIter, Iter, IterMut, Slice, SliceMut, SliceRef,
+    SoaClone, SoaRaw, Soars, iter_raw::IterRaw,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -792,46 +791,6 @@ where
     /// Allocate a `Vec<T>` and fill it by moving the contents of `value`.
     fn from(value: Soa<T>) -> Self {
         value.into_iter().collect()
-    }
-}
-
-impl<T> From<&Slice<T>> for Vec<T>
-where
-    T: SoaClone,
-{
-    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
-    fn from(value: &Slice<T>) -> Self {
-        value.iter().map(SoaClone::soa_clone).collect()
-    }
-}
-
-impl<T> From<&mut Slice<T>> for Vec<T>
-where
-    T: SoaClone,
-{
-    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
-    fn from(value: &mut Slice<T>) -> Self {
-        value.as_ref().into()
-    }
-}
-
-impl<T> From<SliceRef<'_, T>> for Vec<T>
-where
-    T: SoaClone,
-{
-    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
-    fn from(value: SliceRef<T>) -> Self {
-        value.as_ref().into()
-    }
-}
-
-impl<T> From<SliceMut<'_, T>> for Vec<T>
-where
-    T: SoaClone,
-{
-    /// Allocate a `Vec<T>` and fill it by cloning `value`'s items.
-    fn from(value: SliceMut<T>) -> Self {
-        value.as_ref().into()
     }
 }
 


### PR DESCRIPTION
Following #36, this PR adds additional impls to the various slice types to make them clonable using the new `SoaClone` derivable trait. This satisfies the most popular request to be able to clone a `Soa` when the types are non-copy, or be able to convert from `Soa` back to a `Vec`. This is progress on #25. This should hopefully be the last big breaking change before we think about promoting to 1.0. 