### PR TITLE
Ensure `soa![Foo; n]` works with n > 2 as intended

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,8 +316,14 @@ pub use soa_rs_derive::SoaClone;
 /// # #[derive(Soars, Debug, PartialEq, Copy, Clone)]
 /// # #[soa_derive(Debug, PartialEq)]
 /// # struct Foo(u8, u16);
-/// let soa = soa![Foo(1, 2); 2];
-/// assert_eq!(soa, soa![Foo(1, 2), Foo(1, 2)]);
+/// let soa = soa![Foo(1, 2); 5];
+/// assert_eq!(soa, soa![
+///     Foo(1, 2),
+///     Foo(1, 2),
+///     Foo(1, 2),
+///     Foo(1, 2),
+///     Foo(1, 2),
+/// ]);
 /// ```
 #[macro_export]
 macro_rules! soa {
@@ -347,10 +353,12 @@ macro_rules! soa {
         {
             let elem = $elem;
             let mut out = $crate::Soa::with(elem.clone());
+            out.reserve($n);
 
             let mut i = 2;
             while i < $n {
                 out.push(elem.clone());
+                i += 1;
             }
 
             out.push(elem);


### PR DESCRIPTION
In regards to #41, I'm providing a simple fix which ensures `soa![Foo; n]` works for arrays with `n` elements by properly incrementing the `i` variable.

I've also provided an optimization for the solution by first reserving `n` and changed the test case to use 5 elements instead of 2 in order to make sure that this edge case is covered in the tests.